### PR TITLE
fix makefile when installing goyacc, and readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ go.mod: $(MAKEFILE_LIST)
 	echo 'module github.com/xdrpp/goxdr' > go.mod
 
 depend: always
-	cd / && go get -u golang.org/x/tools/cmd/goyacc
+	cd / && go install golang.org/x/tools/cmd/goyacc@latest
 
 RECURSE = for dir in $(CMDS); do cd cmd/$$dir && $(MAKE) $@; done
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ attractive alternative to other go XDR compilers for many situations:
 
 To install goxdr, run:
 
-    go get github.com/xdrpp/goxdr/cmd/goxdr
+    go install github.com/xdrpp/goxdr/cmd/goxdr
 
 To use the latest development version within a go module (i.e., below
 a directory with a `go.mod` file), run:


### PR DESCRIPTION
`go get` is no longer the way to install go binaries, use `go install` instead

addresses https://github.com/xdrpp/goxdr/issues/2