### PR TITLE
Allow ' in constant declarations

### DIFF
--- a/cmd/goxdr/goxdr.go
+++ b/cmd/goxdr/goxdr.go
@@ -494,7 +494,10 @@ func (r *rpc_const) emit(e *emitter) {
 	if r.comment != "" {
 		e.printf("%s\n", r.comment)
 	}
-	e.printf("const %s = %s\n", r.id, r.val)
+	// Strip the character '\'' from r.val before printing constants; 
+	// golang supports _ but not '
+	valStr := strings.ReplaceAll(r.val.String(), "'", "")
+	e.printf("const %s = %s\n", r.id, valStr)
 }
 
 func (r0 *rpc_typedef) emit(e *emitter) {

--- a/cmd/goxdr/goxdr.go
+++ b/cmd/goxdr/goxdr.go
@@ -494,9 +494,9 @@ func (r *rpc_const) emit(e *emitter) {
 	if r.comment != "" {
 		e.printf("%s\n", r.comment)
 	}
-	// Strip the character '\'' from r.val before printing constants; 
+	// Replace the character '\'' with '_' in r.val before printing constants; 
 	// golang supports _ but not '
-	valStr := strings.ReplaceAll(r.val.String(), "'", "")
+	valStr := strings.ReplaceAll(r.val.String(), "'", "_")
 	e.printf("const %s = %s\n", r.id, valStr)
 }
 

--- a/cmd/goxdr/lex.go
+++ b/cmd/goxdr/lex.go
@@ -319,7 +319,7 @@ func (l *Lexer) skipLine() {
 }
 
 func isDigit(c rune) bool {
-	return (c >= '0' && c <= '9') || c == '_' || c == '\''
+	return (c >= '0' && c <= '9') || c == '\''
 }
 
 func isHexDigit(c rune) bool {
@@ -327,7 +327,7 @@ func isHexDigit(c rune) bool {
 		return true
 	}
 	c &^= 0x20
-	return (c >= 'A' && c <= 'F') || c == '_' || c == '\''
+	return (c >= 'A' && c <= 'F') || c == '\''
 }
 
 func isIdStart(c rune) bool {

--- a/cmd/goxdr/lex.go
+++ b/cmd/goxdr/lex.go
@@ -319,7 +319,7 @@ func (l *Lexer) skipLine() {
 }
 
 func isDigit(c rune) bool {
-	return c >= '0' && c <= '9'
+	return (c >= '0' && c <= '9') || c == '_' || c == '\''
 }
 
 func isHexDigit(c rune) bool {
@@ -327,7 +327,7 @@ func isHexDigit(c rune) bool {
 		return true
 	}
 	c &^= 0x20
-	return c >= 'A' && c <= 'F'
+	return (c >= 'A' && c <= 'F') || c == '_' || c == '\''
 }
 
 func isIdStart(c rune) bool {

--- a/cmd/goxdr/testdata/testxdr.x
+++ b/cmd/goxdr/testdata/testxdr.x
@@ -34,6 +34,9 @@ default:
 
 typedef U2 A1[5];
 
+const C1 = 1'000'000;
+const C2 = 0xABCD'EF_01;
+
 struct A2 {
      A1 a[4];
      E1 e[4];

--- a/cmd/goxdr/testdata/testxdr.x
+++ b/cmd/goxdr/testdata/testxdr.x
@@ -35,7 +35,7 @@ default:
 typedef U2 A1[5];
 
 const C1 = 1'000'000;
-const C2 = 0xABCD'EF_01;
+const C2 = 0xABCD'EF'01;
 
 struct A2 {
      A1 a[4];


### PR DESCRIPTION
Slightly improves readability of XDR files to allow separator of ' in constant declarations.

Golang only allows _ in constant declarations, so ' is replaced by _ in the generated go file.