### PR TITLE
Fix arena checkptr crash under -race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+          cache: true
+
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
+
+      - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - run: |
+          cat > go.mod <<'EOF'
+          module github.com/xdrpp/goxdr
+
+          go 1.24.0
+
+          require golang.org/x/tools v0.31.0
+          EOF
+
+      - run: go generate
+        working-directory: cmd/goxdr
+
+      - run: sed -e 's|^[ 	]*//line|//line|' parse.go > parse.go~ && mv -f parse.go~ parse.go
+        working-directory: cmd/goxdr
+
+      - run: go build -o cmd/goxdr/goxdr ./cmd/goxdr
+
+      - run: cp cmd/goxdr/goxdr ./goxdr
+
+      - run: ./goxdr -enum-comments -p rpc -o rpc/rpc_msg.go rpc/rpc_msg.x
+
+      - run: ./goxdr -B -p xdr -o xdr/boilerplate.go
+
+      - run: ./goxdr -enum-comments -p rpc_test -o rpc/prot_test.go rpc/prot_test.x
+
+      - run: go test -v ./xdr ./rpc
+
+      - run: cd cmd/goxdr && go test -v
+
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+          cache: true
+
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
+
+      - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - run: |
+          cat > go.mod <<'EOF'
+          module github.com/xdrpp/goxdr
+
+          go 1.24.0
+
+          require golang.org/x/tools v0.31.0
+          EOF
+
+      - run: go generate
+        working-directory: cmd/goxdr
+
+      - run: sed -e 's|^[ 	]*//line|//line|' parse.go > parse.go~ && mv -f parse.go~ parse.go
+        working-directory: cmd/goxdr
+
+      - run: go build -o cmd/goxdr/goxdr ./cmd/goxdr
+
+      - run: cp cmd/goxdr/goxdr ./goxdr
+
+      - run: ./goxdr -enum-comments -p rpc -o rpc/rpc_msg.go rpc/rpc_msg.x
+
+      - run: ./goxdr -B -p xdr -o xdr/boilerplate.go
+
+      - run: ./goxdr -enum-comments -p rpc_test -o rpc/prot_test.go rpc/prot_test.x
+
+      - run: go test -race -v ./xdr ./rpc
+
+      - run: cd cmd/goxdr && go test -race -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
       - run: ./goxdr -enum-comments -p rpc_test -o rpc/prot_test.go rpc/prot_test.x
 
+      - run: go build ./cmd/gorpc
+
       - run: go test -v ./xdr ./rpc
 
       - run: cd cmd/goxdr && go test -v
@@ -95,6 +97,8 @@ jobs:
       - run: ./goxdr -B -p xdr -o xdr/boilerplate.go
 
       - run: ./goxdr -enum-comments -p rpc_test -o rpc/prot_test.go rpc/prot_test.x
+
+      - run: go build ./cmd/gorpc
 
       - run: go test -race -v ./xdr ./rpc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: '1.24.x'
           cache: true
 
-      - run: go install golang.org/x/tools/cmd/goyacc@latest
+      - run: go install golang.org/x/tools/cmd/goyacc@v0.31.0
 
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
@@ -67,7 +67,7 @@ jobs:
           go-version: '1.24.x'
           cache: true
 
-      - run: go install golang.org/x/tools/cmd/goyacc@latest
+      - run: go install golang.org/x/tools/cmd/goyacc@v0.31.0
 
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 

--- a/xdr/arena.go
+++ b/xdr/arena.go
@@ -78,9 +78,13 @@ func contains[T any](slice []T, ptr *T) bool {
 		return false
 	}
 
-	first := unsafe.Pointer(&slice[0])
-	last := unsafe.Pointer(uintptr(first) + uintptr(len(slice))*unsafe.Sizeof(slice[0]))
+	size := unsafe.Sizeof(slice[0])
+	first := uintptr(unsafe.Pointer(&slice[0]))
+	last := uintptr(unsafe.Pointer(&slice[len(slice)-1]))
+	addr := uintptr(unsafe.Pointer(ptr))
 
-	ptrAddr := unsafe.Pointer(ptr)
-	return uintptr(ptrAddr) >= uintptr(first) && uintptr(ptrAddr) < uintptr(last)
+	if size == 0 {
+		return addr == first
+	}
+	return addr >= first && addr <= last && (addr-first)%size == 0
 }

--- a/xdr/arena_test.go
+++ b/xdr/arena_test.go
@@ -1,0 +1,9 @@
+package xdr
+
+import "testing"
+
+func TestArenaRecycleOwnedObject(t *testing.T) {
+	arena := NewArena[int](1, func(*int) {})
+	obj := arena.Get()
+	arena.Recycle(obj)
+}


### PR DESCRIPTION
## Summary
- avoid one-past-end pointer arithmetic in arena slab membership checks
- add a regression test covering recycle of an arena-owned object under -race